### PR TITLE
Refactor O mark styling to use CSS pseudo-element circle

### DIFF
--- a/TicTacToe/wwwroot/css/game.css
+++ b/TicTacToe/wwwroot/css/game.css
@@ -46,11 +46,23 @@
 }
 
 .mark-O {
-    color: var(--neon-pink);
-    text-shadow:
+    color: transparent;
+    position: relative;
+}
+
+.mark-O::after {
+    content: '';
+    position: absolute;
+    width: 60px;
+    height: 60px;
+    border: 6px solid var(--neon-pink);
+    border-radius: 50%;
+    box-shadow:
         0 0 10px rgba(255, 0, 255, 0.8),
         0 0 20px rgba(255, 0, 255, 0.5),
-        0 0 40px rgba(255, 0, 255, 0.3);
+        0 0 40px rgba(255, 0, 255, 0.3),
+        inset 0 0 10px rgba(255, 0, 255, 0.8),
+        inset 0 0 20px rgba(255, 0, 255, 0.5);
 }
 
 /* ===== ANIMATIONS ===== */
@@ -307,6 +319,12 @@
 
     .cell {
         font-size: 2rem;
+    }
+
+    .mark-O::after {
+        width: 45px;
+        height: 45px;
+        border-width: 5px;
     }
 
     .retro-title {


### PR DESCRIPTION
## Summary
Refactored the O mark styling in the TicTacToe game to use a CSS pseudo-element (`::after`) that renders a circular border instead of relying on text-shadow effects. This improves visual consistency and provides better control over the O mark appearance.

## Key Changes
- Changed `.mark-O` from displaying colored text with text-shadow to using a transparent text with a positioned pseudo-element
- Created `.mark-O::after` pseudo-element that renders a 60px circle with a 6px neon pink border
- Enhanced the glow effect by adding inset box-shadows in addition to the outer box-shadows for a more pronounced neon appearance
- Added responsive styling for the pseudo-element in the mobile breakpoint, scaling the circle to 45px with proportional border width (5px)

## Implementation Details
- The O mark is now rendered as a geometric circle using `border-radius: 50%` rather than as styled text
- The pseudo-element uses `position: absolute` and `position: relative` on the parent to properly position the circle
- Multiple layered box-shadows create the neon glow effect with both outer and inset shadows for depth
- Mobile responsiveness is maintained with adjusted dimensions for smaller screens

https://claude.ai/code/session_01AaTMmCXyAuL2eHwDZbVmQN