### PR TITLE
Add Voxelized Foliage WebGPU experiment

### DIFF
--- a/MultiPlayer.slnx
+++ b/MultiPlayer.slnx
@@ -3,4 +3,5 @@
   <Project Path="TicTacToe/TicTacToe.csproj" />
   <Project Path="LightCycles/LightCycles.csproj" />
   <Project Path="Asteroids/Asteroids.csproj" />
+  <Project Path="VoxelFoliage/VoxelFoliage.csproj" />
 </Solution>

--- a/Portal/Portal.csproj
+++ b/Portal/Portal.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\TicTacToe\TicTacToe.csproj" />
     <ProjectReference Include="..\LightCycles\LightCycles.csproj" />
     <ProjectReference Include="..\Asteroids\Asteroids.csproj" />
+    <ProjectReference Include="..\VoxelFoliage\VoxelFoliage.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Portal/Program.cs
+++ b/Portal/Program.cs
@@ -1,6 +1,7 @@
 using TicTacToe;
 using LightCycles;
 using Asteroids;
+using VoxelFoliage;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,6 +15,7 @@ builder.Services.AddSignalR();
 builder.Services.AddTicTacToe(builder.Configuration);
 builder.Services.AddLightCycles(builder.Configuration);
 builder.Services.AddAsteroids(builder.Configuration);
+builder.Services.AddVoxelFoliage();
 
 var app = builder.Build();
 
@@ -35,5 +37,6 @@ app.MapControllerRoute(
 app.MapTicTacToe();
 app.MapLightCycles();
 app.MapAsteroids();
+app.MapVoxelFoliage();
 
 app.Run();

--- a/Portal/Views/Home/Index.cshtml
+++ b/Portal/Views/Home/Index.cshtml
@@ -35,6 +35,12 @@
             <div class="game-card-title">ASTEROIDS</div>
             <div class="game-card-desc">DESTROY THE ROCKS</div>
         </a>
+
+        <a href="/foliage" class="game-card game-card-foliage">
+            <div class="game-card-icon game-card-icon-foliage">&#127794;&#127807;</div>
+            <div class="game-card-title">VOXEL FOLIAGE</div>
+            <div class="game-card-desc">WEBGPU EXPERIMENT</div>
+        </a>
     </div>
 
     <p class="retro-subtitle mt-5" style="font-size: 0.5rem; color: #555;">SELECT A GAME TO BEGIN</p>
@@ -156,6 +162,21 @@
         .game-card-icon-asteroids {
             color: #00ff41;
             text-shadow: 0 0 10px rgba(0, 255, 65, 0.7);
+        }
+
+        .game-card-foliage {
+            border-color: #88ff44;
+            box-shadow: 0 0 15px rgba(136, 255, 68, 0.3), inset 0 0 15px rgba(136, 255, 68, 0.05);
+        }
+
+        .game-card-foliage:hover {
+            border-color: #fff;
+            box-shadow: 0 0 25px rgba(136, 255, 68, 0.5), inset 0 0 25px rgba(136, 255, 68, 0.1);
+        }
+
+        .game-card-icon-foliage {
+            color: #88ff44;
+            text-shadow: 0 0 10px rgba(136, 255, 68, 0.7);
         }
 
         /* Background scene visibility */

--- a/VoxelFoliage/Controllers/FoliageController.cs
+++ b/VoxelFoliage/Controllers/FoliageController.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace VoxelFoliage.Controllers;
+
+[Route("foliage")]
+public class FoliageController : Controller
+{
+    [HttpGet("")]
+    public IActionResult Index()
+    {
+        return View();
+    }
+}

--- a/VoxelFoliage/GlobalUsings.cs
+++ b/VoxelFoliage/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Microsoft.AspNetCore.Http;
+global using Microsoft.Extensions.DependencyInjection;

--- a/VoxelFoliage/Views/Foliage/Index.cshtml
+++ b/VoxelFoliage/Views/Foliage/Index.cshtml
@@ -1,0 +1,35 @@
+@{
+    ViewData["Title"] = "VOXEL FOLIAGE";
+}
+
+@section Styles {
+    <link rel="stylesheet" href="~/_content/VoxelFoliage/css/foliage.css" asp-append-version="true" />
+}
+
+<div class="foliage-container">
+    <canvas id="foliageCanvas"></canvas>
+
+    <div id="webgpuFallback" class="foliage-fallback" style="display:none;">
+        <div class="foliage-fallback-text">WEBGPU NOT SUPPORTED</div>
+        <p class="foliage-fallback-sub">Your browser does not support WebGPU.<br/>Try Chrome 113+ or Edge 113+.</p>
+        <a href="/" class="btn-arcade mt-4">BACK TO ARCADE</a>
+    </div>
+
+    <div id="foliageControls" class="foliage-controls">
+        <a href="/" class="foliage-back-link">&#9668; ARCADE</a>
+        <div class="foliage-control-group">
+            <button id="spinToggle" class="foliage-btn active" title="Toggle Auto-Spin">SPIN</button>
+            <label class="foliage-slider-label">
+                SPEED
+                <input type="range" id="speedSlider" class="foliage-slider" min="1" max="20" value="5" />
+            </label>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="~/_content/VoxelFoliage/js/camera.js" asp-append-version="true"></script>
+    <script src="~/_content/VoxelFoliage/js/voxel-geometry.js" asp-append-version="true"></script>
+    <script src="~/_content/VoxelFoliage/js/foliage-generator.js" asp-append-version="true"></script>
+    <script src="~/_content/VoxelFoliage/js/foliage.js" asp-append-version="true"></script>
+}

--- a/VoxelFoliage/VoxelFoliage.csproj
+++ b/VoxelFoliage/VoxelFoliage.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/VoxelFoliage/VoxelFoliageServiceExtensions.cs
+++ b/VoxelFoliage/VoxelFoliageServiceExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+namespace VoxelFoliage;
+
+public static class VoxelFoliageServiceExtensions
+{
+    public static IServiceCollection AddVoxelFoliage(this IServiceCollection services)
+    {
+        return services;
+    }
+
+    public static IEndpointRouteBuilder MapVoxelFoliage(this IEndpointRouteBuilder endpoints)
+    {
+        return endpoints;
+    }
+}

--- a/VoxelFoliage/wwwroot/css/foliage.css
+++ b/VoxelFoliage/wwwroot/css/foliage.css
@@ -1,0 +1,155 @@
+.foliage-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    background: #0a0a1a;
+}
+
+#foliageCanvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+/* Fallback */
+.foliage-fallback {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    z-index: 10;
+}
+
+.foliage-fallback-text {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 1.2rem;
+    color: #ff4444;
+    text-shadow: 0 0 15px rgba(255, 68, 68, 0.7);
+    margin-bottom: 1rem;
+}
+
+.foliage-fallback-sub {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.45rem;
+    color: #888;
+    line-height: 2;
+}
+
+/* Controls overlay */
+.foliage-controls {
+    position: fixed;
+    bottom: 1.2rem;
+    left: 1.2rem;
+    right: 1.2rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    z-index: 10;
+    pointer-events: none;
+}
+
+.foliage-controls > * {
+    pointer-events: auto;
+}
+
+.foliage-back-link {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.5rem;
+    color: var(--neon-cyan, #00ffff);
+    text-decoration: none;
+    text-shadow: 0 0 8px rgba(0, 255, 255, 0.5);
+    padding: 0.5rem 0.75rem;
+    background: rgba(18, 18, 42, 0.85);
+    border: 2px solid var(--neon-cyan, #00ffff);
+    transition: all 0.2s ease;
+}
+
+.foliage-back-link:hover {
+    color: #fff;
+    border-color: #fff;
+    box-shadow: 0 0 15px rgba(0, 255, 255, 0.5);
+    text-decoration: none;
+}
+
+.foliage-control-group {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    background: rgba(18, 18, 42, 0.85);
+    border: 2px solid #88ff44;
+    box-shadow: 0 0 10px rgba(136, 255, 68, 0.2);
+    padding: 0.5rem 1rem;
+}
+
+.foliage-btn {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.4rem;
+    color: #555;
+    background: transparent;
+    border: 2px solid #555;
+    padding: 0.4rem 0.6rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.foliage-btn.active {
+    color: #88ff44;
+    border-color: #88ff44;
+    text-shadow: 0 0 8px rgba(136, 255, 68, 0.7);
+    box-shadow: 0 0 8px rgba(136, 255, 68, 0.3);
+}
+
+.foliage-btn:hover {
+    color: #fff;
+    border-color: #fff;
+}
+
+.foliage-slider-label {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.35rem;
+    color: #88ff44;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+}
+
+.foliage-slider {
+    width: 80px;
+    height: 4px;
+    -webkit-appearance: none;
+    appearance: none;
+    background: #333;
+    outline: none;
+    cursor: pointer;
+}
+
+.foliage-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 12px;
+    height: 12px;
+    background: #88ff44;
+    box-shadow: 0 0 6px rgba(136, 255, 68, 0.6);
+    cursor: pointer;
+}
+
+.foliage-slider::-moz-range-thumb {
+    width: 12px;
+    height: 12px;
+    background: #88ff44;
+    border: none;
+    box-shadow: 0 0 6px rgba(136, 255, 68, 0.6);
+    cursor: pointer;
+}
+
+@media (max-width: 576px) {
+    .foliage-controls {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.5rem;
+    }
+}

--- a/VoxelFoliage/wwwroot/js/camera.js
+++ b/VoxelFoliage/wwwroot/js/camera.js
@@ -1,0 +1,152 @@
+var VoxelCamera = (function () {
+    'use strict';
+
+    function create(options) {
+        var cam = {
+            theta: options.theta || 0.5,
+            phi: options.phi || 0.6,
+            radius: options.radius || 25,
+            center: options.center || [0, 4, 0],
+            minRadius: 8,
+            maxRadius: 60,
+            minPhi: 0.1,
+            maxPhi: Math.PI / 2 - 0.05,
+            autoSpin: true,
+            spinSpeed: 0.005,
+            dragging: false,
+            lastX: 0,
+            lastY: 0,
+            resumeTimer: null
+        };
+        return cam;
+    }
+
+    function getEye(cam) {
+        var x = cam.center[0] + cam.radius * Math.sin(cam.phi) * Math.cos(cam.theta);
+        var y = cam.center[1] + cam.radius * Math.cos(cam.phi);
+        var z = cam.center[2] + cam.radius * Math.sin(cam.phi) * Math.sin(cam.theta);
+        return [x, y, z];
+    }
+
+    function viewMatrix(cam) {
+        var eye = getEye(cam);
+        var center = cam.center;
+        var up = [0, 1, 0];
+        return lookAt(eye, center, up);
+    }
+
+    function projectionMatrix(aspect, fov, near, far) {
+        fov = fov || Math.PI / 4;
+        near = near || 0.1;
+        far = far || 200;
+        var f = 1.0 / Math.tan(fov / 2);
+        var nf = 1.0 / (near - far);
+        return new Float32Array([
+            f / aspect, 0, 0, 0,
+            0, f, 0, 0,
+            0, 0, (far + near) * nf, -1,
+            0, 0, 2 * far * near * nf, 0
+        ]);
+    }
+
+    function viewProjectionMatrix(cam, aspect) {
+        var v = viewMatrix(cam);
+        var p = projectionMatrix(aspect);
+        return multiply(p, v);
+    }
+
+    function update(cam, dt) {
+        if (cam.autoSpin && !cam.dragging) {
+            cam.theta += cam.spinSpeed * dt * 60;
+        }
+    }
+
+    function attachControls(cam, canvas) {
+        canvas.addEventListener('pointerdown', function (e) {
+            cam.dragging = true;
+            cam.lastX = e.clientX;
+            cam.lastY = e.clientY;
+            if (cam.resumeTimer) {
+                clearTimeout(cam.resumeTimer);
+                cam.resumeTimer = null;
+            }
+            canvas.setPointerCapture(e.pointerId);
+        });
+
+        canvas.addEventListener('pointermove', function (e) {
+            if (!cam.dragging) return;
+            var dx = e.clientX - cam.lastX;
+            var dy = e.clientY - cam.lastY;
+            cam.lastX = e.clientX;
+            cam.lastY = e.clientY;
+            cam.theta -= dx * 0.005;
+            cam.phi = Math.max(cam.minPhi, Math.min(cam.maxPhi, cam.phi - dy * 0.005));
+        });
+
+        canvas.addEventListener('pointerup', function (e) {
+            cam.dragging = false;
+            canvas.releasePointerCapture(e.pointerId);
+            if (cam.autoSpin) {
+                cam.resumeTimer = setTimeout(function () {
+                    cam.resumeTimer = null;
+                }, 2000);
+            }
+        });
+
+        canvas.addEventListener('wheel', function (e) {
+            e.preventDefault();
+            cam.radius = Math.max(cam.minRadius, Math.min(cam.maxRadius, cam.radius + e.deltaY * 0.05));
+        }, { passive: false });
+    }
+
+    // --- Matrix math helpers ---
+
+    function lookAt(eye, center, up) {
+        var zx = eye[0] - center[0], zy = eye[1] - center[1], zz = eye[2] - center[2];
+        var zLen = Math.sqrt(zx * zx + zy * zy + zz * zz);
+        zx /= zLen; zy /= zLen; zz /= zLen;
+
+        var xx = up[1] * zz - up[2] * zy;
+        var xy = up[2] * zx - up[0] * zz;
+        var xz = up[0] * zy - up[1] * zx;
+        var xLen = Math.sqrt(xx * xx + xy * xy + xz * xz);
+        xx /= xLen; xy /= xLen; xz /= xLen;
+
+        var yx = zy * xz - zz * xy;
+        var yy = zz * xx - zx * xz;
+        var yz = zx * xy - zy * xx;
+
+        return new Float32Array([
+            xx, yx, zx, 0,
+            xy, yy, zy, 0,
+            xz, yz, zz, 0,
+            -(xx * eye[0] + xy * eye[1] + xz * eye[2]),
+            -(yx * eye[0] + yy * eye[1] + yz * eye[2]),
+            -(zx * eye[0] + zy * eye[1] + zz * eye[2]),
+            1
+        ]);
+    }
+
+    function multiply(a, b) {
+        var out = new Float32Array(16);
+        for (var i = 0; i < 4; i++) {
+            for (var j = 0; j < 4; j++) {
+                out[i * 4 + j] = 0;
+                for (var k = 0; k < 4; k++) {
+                    out[i * 4 + j] += a[k * 4 + j] * b[i * 4 + k];
+                }
+            }
+        }
+        return out;
+    }
+
+    return {
+        create: create,
+        getEye: getEye,
+        viewMatrix: viewMatrix,
+        projectionMatrix: projectionMatrix,
+        viewProjectionMatrix: viewProjectionMatrix,
+        update: update,
+        attachControls: attachControls
+    };
+})();

--- a/VoxelFoliage/wwwroot/js/foliage-generator.js
+++ b/VoxelFoliage/wwwroot/js/foliage-generator.js
@@ -1,0 +1,208 @@
+var FoliageGenerator = (function () {
+    'use strict';
+
+    // Seeded random for reproducibility
+    function mulberry32(seed) {
+        return function () {
+            seed |= 0; seed = seed + 0x6D2B79F5 | 0;
+            var t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+            t = t + Math.imul(t ^ (t >>> 7), 61 | t) ^ t;
+            return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+        };
+    }
+
+    // Color palettes
+    var TRUNK_COLORS = [
+        { r: 0.35, g: 0.22, b: 0.12 },
+        { r: 0.40, g: 0.25, b: 0.14 },
+        { r: 0.30, g: 0.18, b: 0.10 }
+    ];
+
+    var LEAF_COLORS = [
+        { r: 0.15, g: 0.55, b: 0.12 },
+        { r: 0.20, g: 0.65, b: 0.15 },
+        { r: 0.12, g: 0.45, b: 0.10 },
+        { r: 0.25, g: 0.70, b: 0.18 },
+        { r: 0.18, g: 0.50, b: 0.08 },
+        { r: 0.30, g: 0.75, b: 0.22 }
+    ];
+
+    var GRASS_COLORS = [
+        { r: 0.10, g: 0.30, b: 0.08 },
+        { r: 0.12, g: 0.35, b: 0.10 },
+        { r: 0.08, g: 0.25, b: 0.06 },
+        { r: 0.14, g: 0.38, b: 0.12 }
+    ];
+
+    var FLOWER_COLORS = [
+        { r: 0.90, g: 0.25, b: 0.40 },
+        { r: 0.95, g: 0.85, b: 0.20 },
+        { r: 0.70, g: 0.30, b: 0.80 },
+        { r: 0.95, g: 0.55, b: 0.20 }
+    ];
+
+    function pick(arr, rng) {
+        return arr[Math.floor(rng() * arr.length)];
+    }
+
+    function generateTree(cx, cz, rng, sizeScale) {
+        var voxels = [];
+        sizeScale = sizeScale || 1.0;
+
+        // Trunk
+        var trunkHeight = Math.floor((4 + rng() * 4) * sizeScale);
+        var trunkBase = Math.max(1, Math.floor(1.5 * sizeScale));
+
+        for (var y = 0; y < trunkHeight; y++) {
+            var width = Math.max(1, Math.floor(trunkBase * (1 - y / trunkHeight * 0.6)));
+            var halfW = Math.floor(width / 2);
+            for (var dx = -halfW; dx <= halfW; dx++) {
+                for (var dz = -halfW; dz <= halfW; dz++) {
+                    var col = pick(TRUNK_COLORS, rng);
+                    voxels.push({ x: cx + dx, y: y + 0.5, z: cz + dz, r: col.r, g: col.g, b: col.b, scale: 1.0, sway: 0.0 });
+                }
+            }
+        }
+
+        // Canopy — spherical cluster(s)
+        var canopyRadius = Math.floor((2.5 + rng() * 2) * sizeScale);
+        var canopyCenterY = trunkHeight + canopyRadius * 0.4;
+        var numClusters = 1 + Math.floor(rng() * 2);
+
+        for (var c = 0; c < numClusters; c++) {
+            var offX = c === 0 ? 0 : (rng() - 0.5) * canopyRadius;
+            var offZ = c === 0 ? 0 : (rng() - 0.5) * canopyRadius;
+            var offY = c === 0 ? 0 : (rng() - 0.5) * canopyRadius * 0.5;
+            var r = canopyRadius * (c === 0 ? 1.0 : 0.6 + rng() * 0.3);
+
+            for (var lx = -Math.ceil(r); lx <= Math.ceil(r); lx++) {
+                for (var ly = -Math.ceil(r); ly <= Math.ceil(r); ly++) {
+                    for (var lz = -Math.ceil(r); lz <= Math.ceil(r); lz++) {
+                        var dist = Math.sqrt(lx * lx + ly * ly + lz * lz);
+                        if (dist <= r && (dist <= r - 0.8 || rng() > 0.3)) {
+                            var col = pick(LEAF_COLORS, rng);
+                            var swayAmount = 0.3 + rng() * 0.7;
+                            voxels.push({
+                                x: cx + lx + offX,
+                                y: canopyCenterY + ly + offY + 0.5,
+                                z: cz + lz + offZ,
+                                r: col.r, g: col.g, b: col.b,
+                                scale: 1.0,
+                                sway: swayAmount
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        return voxels;
+    }
+
+    function generateBush(cx, cz, rng) {
+        var voxels = [];
+        var r = 1 + Math.floor(rng() * 2);
+
+        for (var lx = -r; lx <= r; lx++) {
+            for (var ly = 0; ly <= r; ly++) {
+                for (var lz = -r; lz <= r; lz++) {
+                    var dist = Math.sqrt(lx * lx + ly * ly + lz * lz);
+                    if (dist <= r + 0.3 && rng() > 0.2) {
+                        var col = pick(LEAF_COLORS, rng);
+                        voxels.push({
+                            x: cx + lx, y: ly + 0.5, z: cz + lz,
+                            r: col.r, g: col.g, b: col.b,
+                            scale: 1.0, sway: 0.2 + rng() * 0.4
+                        });
+                    }
+                }
+            }
+        }
+
+        // Occasional flower on top
+        if (rng() > 0.5) {
+            var col = pick(FLOWER_COLORS, rng);
+            voxels.push({
+                x: cx, y: r + 1.5, z: cz,
+                r: col.r, g: col.g, b: col.b,
+                scale: 0.7, sway: 0.8
+            });
+        }
+
+        return voxels;
+    }
+
+    function generateGround(halfSize, rng) {
+        var voxels = [];
+        for (var gx = -halfSize; gx <= halfSize; gx++) {
+            for (var gz = -halfSize; gz <= halfSize; gz++) {
+                // Circular ground
+                if (gx * gx + gz * gz > (halfSize + 2) * (halfSize + 2)) continue;
+                var col = pick(GRASS_COLORS, rng);
+                voxels.push({
+                    x: gx, y: -0.5, z: gz,
+                    r: col.r, g: col.g, b: col.b,
+                    scale: 1.0, sway: 0.0
+                });
+            }
+        }
+        return voxels;
+    }
+
+    function generateScene(seed) {
+        seed = seed || 42;
+        var rng = mulberry32(seed);
+        var voxels = [];
+
+        // Ground
+        var groundSize = 12;
+        voxels = voxels.concat(generateGround(groundSize, rng));
+
+        // Main center tree (large)
+        voxels = voxels.concat(generateTree(0, 0, rng, 1.3));
+
+        // Surrounding trees
+        var treePositions = [
+            { x: -7, z: -5 }, { x: 6, z: -6 }, { x: -5, z: 7 },
+            { x: 8, z: 4 }, { x: -9, z: 1 }, { x: 3, z: 8 },
+            { x: -3, z: -9 }
+        ];
+
+        for (var t = 0; t < treePositions.length; t++) {
+            var size = 0.6 + rng() * 0.7;
+            voxels = voxels.concat(generateTree(treePositions[t].x, treePositions[t].z, rng, size));
+        }
+
+        // Bushes
+        var bushCount = 5 + Math.floor(rng() * 5);
+        for (var b = 0; b < bushCount; b++) {
+            var bx = Math.floor((rng() - 0.5) * groundSize * 2);
+            var bz = Math.floor((rng() - 0.5) * groundSize * 2);
+            if (bx * bx + bz * bz < groundSize * groundSize) {
+                voxels = voxels.concat(generateBush(bx, bz, rng));
+            }
+        }
+
+        // Scattered flowers
+        var flowerCount = 8 + Math.floor(rng() * 8);
+        for (var f = 0; f < flowerCount; f++) {
+            var fx = (rng() - 0.5) * groundSize * 2;
+            var fz = (rng() - 0.5) * groundSize * 2;
+            if (fx * fx + fz * fz < groundSize * groundSize) {
+                var col = pick(FLOWER_COLORS, rng);
+                voxels.push({
+                    x: fx, y: 0.2, z: fz,
+                    r: col.r, g: col.g, b: col.b,
+                    scale: 0.4 + rng() * 0.3,
+                    sway: 0.5 + rng() * 0.5
+                });
+            }
+        }
+
+        return voxels;
+    }
+
+    return {
+        generateScene: generateScene
+    };
+})();

--- a/VoxelFoliage/wwwroot/js/foliage.js
+++ b/VoxelFoliage/wwwroot/js/foliage.js
@@ -1,0 +1,326 @@
+(function () {
+    'use strict';
+
+    var canvas = document.getElementById('foliageCanvas');
+    var fallback = document.getElementById('webgpuFallback');
+    var controls = document.getElementById('foliageControls');
+    var spinToggle = document.getElementById('spinToggle');
+    var speedSlider = document.getElementById('speedSlider');
+
+    // WGSL shaders
+    var shaderCode = /* wgsl */`
+        struct Uniforms {
+            viewProjection: mat4x4f,
+            lightDir: vec3f,
+            time: f32,
+            eyePos: vec3f,
+            _pad: f32,
+        }
+
+        @group(0) @binding(0) var<uniform> u: Uniforms;
+
+        struct VertexInput {
+            @location(0) position: vec3f,
+            @location(1) normal: vec3f,
+            // Instance attributes
+            @location(2) instPos: vec3f,
+            @location(3) instColor: vec3f,
+            @location(4) instScale: f32,
+            @location(5) instSway: f32,
+        }
+
+        struct VertexOutput {
+            @builtin(position) clipPos: vec4f,
+            @location(0) color: vec3f,
+            @location(1) normal: vec3f,
+            @location(2) worldPos: vec3f,
+        }
+
+        @vertex fn vs_main(v: VertexInput) -> VertexOutput {
+            var worldPos = v.position * v.instScale + v.instPos;
+
+            // Wind sway for foliage
+            let swayX = sin(u.time * 1.8 + worldPos.z * 0.4 + worldPos.x * 0.3) * v.instSway * 0.18;
+            let swayZ = cos(u.time * 1.3 + worldPos.x * 0.5) * v.instSway * 0.08;
+            worldPos.x += swayX;
+            worldPos.z += swayZ;
+
+            var out: VertexOutput;
+            out.clipPos = u.viewProjection * vec4f(worldPos, 1.0);
+            out.color = v.instColor;
+            out.normal = v.normal;
+            out.worldPos = worldPos;
+            return out;
+        }
+
+        @fragment fn fs_main(f: VertexOutput) -> @location(0) vec4f {
+            let n = normalize(f.normal);
+            let l = normalize(u.lightDir);
+            let ndotl = max(dot(n, l), 0.0);
+
+            // Ambient + diffuse
+            let ambient = 0.35;
+            let diffuse = 0.65 * ndotl;
+            var lit = f.color * (ambient + diffuse);
+
+            // Subtle distance fog
+            let dist = distance(f.worldPos, u.eyePos);
+            let fogStart = 30.0;
+            let fogEnd = 80.0;
+            let fogColor = vec3f(0.04, 0.04, 0.10);
+            let fogFactor = clamp((dist - fogStart) / (fogEnd - fogStart), 0.0, 1.0);
+            lit = mix(lit, fogColor, fogFactor);
+
+            return vec4f(lit, 1.0);
+        }
+    `;
+
+    async function init() {
+        // Check WebGPU support
+        if (!navigator.gpu) {
+            canvas.style.display = 'none';
+            controls.style.display = 'none';
+            fallback.style.display = 'block';
+            return;
+        }
+
+        var adapter = await navigator.gpu.requestAdapter();
+        if (!adapter) {
+            canvas.style.display = 'none';
+            controls.style.display = 'none';
+            fallback.style.display = 'block';
+            return;
+        }
+
+        var device = await adapter.requestDevice();
+        var context = canvas.getContext('webgpu');
+        var format = navigator.gpu.getPreferredCanvasFormat();
+
+        context.configure({
+            device: device,
+            format: format,
+            alphaMode: 'opaque'
+        });
+
+        // Resize canvas to pixel size
+        function resize() {
+            var dpr = window.devicePixelRatio || 1;
+            canvas.width = Math.floor(canvas.clientWidth * dpr);
+            canvas.height = Math.floor(canvas.clientHeight * dpr);
+        }
+        resize();
+        window.addEventListener('resize', resize);
+
+        // Generate scene
+        var voxels = FoliageGenerator.generateScene(42);
+        var cubeMesh = VoxelGeometry.createCubeMesh();
+        var instanceData = VoxelGeometry.buildInstanceBuffer(voxels);
+
+        // Vertex buffer (cube mesh)
+        var vertexBuffer = device.createBuffer({
+            size: cubeMesh.positions.byteLength,
+            usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST
+        });
+        device.queue.writeBuffer(vertexBuffer, 0, cubeMesh.positions);
+
+        // Index buffer
+        var indexBuffer = device.createBuffer({
+            size: cubeMesh.indices.byteLength,
+            usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST
+        });
+        device.queue.writeBuffer(indexBuffer, 0, cubeMesh.indices);
+
+        // Instance buffer
+        var instanceBuffer = device.createBuffer({
+            size: instanceData.byteLength,
+            usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST
+        });
+        device.queue.writeBuffer(instanceBuffer, 0, instanceData);
+
+        // Uniform buffer: mat4 (64) + vec3 lightDir (12) + f32 time (4) + vec3 eyePos (12) + f32 pad (4) = 96 bytes
+        var uniformBuffer = device.createBuffer({
+            size: 96,
+            usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+        });
+
+        // Bind group layout + bind group
+        var bindGroupLayout = device.createBindGroupLayout({
+            entries: [{
+                binding: 0,
+                visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+                buffer: { type: 'uniform' }
+            }]
+        });
+
+        var bindGroup = device.createBindGroup({
+            layout: bindGroupLayout,
+            entries: [{ binding: 0, resource: { buffer: uniformBuffer } }]
+        });
+
+        // Shader module
+        var shaderModule = device.createShaderModule({ code: shaderCode });
+
+        // Pipeline
+        var pipeline = device.createRenderPipeline({
+            layout: device.createPipelineLayout({ bindGroupLayouts: [bindGroupLayout] }),
+            vertex: {
+                module: shaderModule,
+                entryPoint: 'vs_main',
+                buffers: [
+                    // Cube vertex: position (vec3f) + normal (vec3f) = stride 24
+                    {
+                        arrayStride: 24,
+                        stepMode: 'vertex',
+                        attributes: [
+                            { shaderLocation: 0, offset: 0, format: 'float32x3' },  // position
+                            { shaderLocation: 1, offset: 12, format: 'float32x3' }  // normal
+                        ]
+                    },
+                    // Instance: pos(3) + color(3) + scale(1) + sway(1) = stride 32
+                    {
+                        arrayStride: 32,
+                        stepMode: 'instance',
+                        attributes: [
+                            { shaderLocation: 2, offset: 0, format: 'float32x3' },   // instPos
+                            { shaderLocation: 3, offset: 12, format: 'float32x3' },  // instColor
+                            { shaderLocation: 4, offset: 24, format: 'float32' },     // instScale
+                            { shaderLocation: 5, offset: 28, format: 'float32' }      // instSway
+                        ]
+                    }
+                ]
+            },
+            fragment: {
+                module: shaderModule,
+                entryPoint: 'fs_main',
+                targets: [{ format: format }]
+            },
+            primitive: {
+                topology: 'triangle-list',
+                cullMode: 'back',
+                frontFace: 'ccw'
+            },
+            depthStencil: {
+                format: 'depth24plus',
+                depthWriteEnabled: true,
+                depthCompare: 'less'
+            }
+        });
+
+        // Depth texture
+        var depthTexture = null;
+        function createDepthTexture() {
+            if (depthTexture) depthTexture.destroy();
+            depthTexture = device.createTexture({
+                size: [canvas.width, canvas.height],
+                format: 'depth24plus',
+                usage: GPUTextureUsage.RENDER_ATTACHMENT
+            });
+        }
+        createDepthTexture();
+
+        // Camera
+        var camera = VoxelCamera.create({
+            theta: 0.5,
+            phi: 0.55,
+            radius: 30,
+            center: [0, 4, 0]
+        });
+        VoxelCamera.attachControls(camera, canvas);
+
+        // UI controls
+        spinToggle.addEventListener('click', function () {
+            camera.autoSpin = !camera.autoSpin;
+            spinToggle.classList.toggle('active', camera.autoSpin);
+        });
+
+        speedSlider.addEventListener('input', function () {
+            camera.spinSpeed = parseFloat(speedSlider.value) * 0.002;
+        });
+        camera.spinSpeed = parseFloat(speedSlider.value) * 0.002;
+
+        // Uniform data
+        var uniformData = new Float32Array(24); // 96 bytes / 4
+        // Light direction (normalized, from upper-right)
+        var lx = 0.4, ly = 0.8, lz = 0.3;
+        var lLen = Math.sqrt(lx * lx + ly * ly + lz * lz);
+        uniformData[16] = lx / lLen;
+        uniformData[17] = ly / lLen;
+        uniformData[18] = lz / lLen;
+
+        var lastTime = performance.now();
+        var totalTime = 0;
+        var lastWidth = canvas.width;
+        var lastHeight = canvas.height;
+
+        function frame() {
+            var now = performance.now();
+            var dt = (now - lastTime) / 1000;
+            lastTime = now;
+            totalTime += dt;
+
+            // Rebuild depth texture on resize
+            if (canvas.width !== lastWidth || canvas.height !== lastHeight) {
+                lastWidth = canvas.width;
+                lastHeight = canvas.height;
+                createDepthTexture();
+            }
+
+            if (canvas.width === 0 || canvas.height === 0) {
+                requestAnimationFrame(frame);
+                return;
+            }
+
+            // Update camera
+            VoxelCamera.update(camera, dt);
+
+            // Build view-projection matrix
+            var aspect = canvas.width / canvas.height;
+            var vp = VoxelCamera.viewProjectionMatrix(camera, aspect);
+            uniformData.set(vp, 0); // mat4 at offset 0
+
+            // Time
+            uniformData[19] = totalTime;
+
+            // Eye position
+            var eye = VoxelCamera.getEye(camera);
+            uniformData[20] = eye[0];
+            uniformData[21] = eye[1];
+            uniformData[22] = eye[2];
+
+            device.queue.writeBuffer(uniformBuffer, 0, uniformData);
+
+            var commandEncoder = device.createCommandEncoder();
+            var textureView = context.getCurrentTexture().createView();
+
+            var renderPass = commandEncoder.beginRenderPass({
+                colorAttachments: [{
+                    view: textureView,
+                    clearValue: { r: 0.04, g: 0.04, b: 0.10, a: 1.0 },
+                    loadOp: 'clear',
+                    storeOp: 'store'
+                }],
+                depthStencilAttachment: {
+                    view: depthTexture.createView(),
+                    depthClearValue: 1.0,
+                    depthLoadOp: 'clear',
+                    depthStoreOp: 'store'
+                }
+            });
+
+            renderPass.setPipeline(pipeline);
+            renderPass.setVertexBuffer(0, vertexBuffer);
+            renderPass.setVertexBuffer(1, instanceBuffer);
+            renderPass.setIndexBuffer(indexBuffer, 'uint16');
+            renderPass.setBindGroup(0, bindGroup);
+            renderPass.drawIndexed(cubeMesh.indexCount, voxels.length);
+            renderPass.end();
+
+            device.queue.submit([commandEncoder.finish()]);
+            requestAnimationFrame(frame);
+        }
+
+        requestAnimationFrame(frame);
+    }
+
+    init();
+})();

--- a/VoxelFoliage/wwwroot/js/voxel-geometry.js
+++ b/VoxelFoliage/wwwroot/js/voxel-geometry.js
@@ -1,0 +1,76 @@
+var VoxelGeometry = (function () {
+    'use strict';
+
+    // Unit cube: 24 vertices (4 per face, unique normals), 36 indices
+    function createCubeMesh() {
+        // positions (x,y,z) + normals (nx,ny,nz) per vertex
+        var positions = new Float32Array([
+            // Front face (z+)
+            -0.5, -0.5,  0.5,   0,  0,  1,
+             0.5, -0.5,  0.5,   0,  0,  1,
+             0.5,  0.5,  0.5,   0,  0,  1,
+            -0.5,  0.5,  0.5,   0,  0,  1,
+            // Back face (z-)
+             0.5, -0.5, -0.5,   0,  0, -1,
+            -0.5, -0.5, -0.5,   0,  0, -1,
+            -0.5,  0.5, -0.5,   0,  0, -1,
+             0.5,  0.5, -0.5,   0,  0, -1,
+            // Top face (y+)
+            -0.5,  0.5,  0.5,   0,  1,  0,
+             0.5,  0.5,  0.5,   0,  1,  0,
+             0.5,  0.5, -0.5,   0,  1,  0,
+            -0.5,  0.5, -0.5,   0,  1,  0,
+            // Bottom face (y-)
+            -0.5, -0.5, -0.5,   0, -1,  0,
+             0.5, -0.5, -0.5,   0, -1,  0,
+             0.5, -0.5,  0.5,   0, -1,  0,
+            -0.5, -0.5,  0.5,   0, -1,  0,
+            // Right face (x+)
+             0.5, -0.5,  0.5,   1,  0,  0,
+             0.5, -0.5, -0.5,   1,  0,  0,
+             0.5,  0.5, -0.5,   1,  0,  0,
+             0.5,  0.5,  0.5,   1,  0,  0,
+            // Left face (x-)
+            -0.5, -0.5, -0.5,  -1,  0,  0,
+            -0.5, -0.5,  0.5,  -1,  0,  0,
+            -0.5,  0.5,  0.5,  -1,  0,  0,
+            -0.5,  0.5, -0.5,  -1,  0,  0
+        ]);
+
+        var indices = new Uint16Array([
+             0,  1,  2,   0,  2,  3,   // front
+             4,  5,  6,   4,  6,  7,   // back
+             8,  9, 10,   8, 10, 11,   // top
+            12, 13, 14,  12, 14, 15,   // bottom
+            16, 17, 18,  16, 18, 19,   // right
+            20, 21, 22,  20, 22, 23    // left
+        ]);
+
+        return { positions: positions, indices: indices, vertexCount: 24, indexCount: 36 };
+    }
+
+    // Build instance data buffer from voxel array
+    // Each voxel: { x, y, z, r, g, b, scale, sway }
+    // Instance layout: vec3 pos, vec3 color, f32 scale, f32 sway = 8 floats
+    function buildInstanceBuffer(voxels) {
+        var data = new Float32Array(voxels.length * 8);
+        for (var i = 0; i < voxels.length; i++) {
+            var v = voxels[i];
+            var off = i * 8;
+            data[off]     = v.x;
+            data[off + 1] = v.y;
+            data[off + 2] = v.z;
+            data[off + 3] = v.r;
+            data[off + 4] = v.g;
+            data[off + 5] = v.b;
+            data[off + 6] = v.scale || 1.0;
+            data[off + 7] = v.sway  || 0.0;
+        }
+        return data;
+    }
+
+    return {
+        createCubeMesh: createCubeMesh,
+        buildInstanceBuffer: buildInstanceBuffer
+    };
+})();


### PR DESCRIPTION
New Razor Class Library (VoxelFoliage) rendering a procedurally generated
voxel tree/plant scene entirely with WebGPU. Features instanced rendering
of thousands of voxel cubes in a single draw call, wind animation via WGSL
vertex shader sway, orbit camera with auto-spin mode (drag to manually
orbit, scroll to zoom), and retro-themed UI controls.

- Procedural foliage: trees with tapered trunks, spherical canopy clusters,
  bushes, flowers, and circular grass ground plane
- WGSL shaders: Lambert lighting + distance fog + wind displacement
- Camera: auto-spin default, manual orbit on drag, adjustable speed slider
- Integrated into Portal at /foliage with game card on home page

https://claude.ai/code/session_012SB2UrCi5TpW6Fx237NPQ3